### PR TITLE
Fixed `exe` method for 'share' and 'system' version of brotli command

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for {{ $dist->name }}:
 
 {{$NEXT}}
 
+v0.2.1
+  [Bug Fixes]
+  - Fixed `exe` method for 'share' and 'system' version of brotli command, GH#2.
+
 v0.2.0    2022-06-17 16:18:02+01:00 Europe/London
   [Bug Fixes]
   - Fixed usage with Alien::Base::Wrapper, GH#1.

--- a/alienfile
+++ b/alienfile
@@ -9,6 +9,10 @@ plugin 'PkgConfig' => (
     pkg_name        => [qw/ libbrotlicommon libbrotlienc libbrotlidec /],
     minimum_version => MINIMUM_VERSION,
 );
+plugin 'Probe::CommandLine' => (
+    command => 'brotli',
+    secondary => 1,
+);
 
 share {
 

--- a/lib/Alien/Brotli.pm
+++ b/lib/Alien/Brotli.pm
@@ -34,7 +34,7 @@ object.
 
 sub exe {
     my ($self) = @_;
-    return path( $self->dist_dir, 'bin', $self->runtime_prop->{command} );
+    return path( $self->bin_dir, $self->runtime_prop->{command} );
 }
 
 =head1 SEE ALSO


### PR DESCRIPTION
Fix for #2 