### PR TITLE
Fix missing bc tool in share build

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -15,6 +15,7 @@ plugin 'Probe::CommandLine' => (
 );
 
 share {
+    requires 'Alien::bc::GNU' => '0';
 
     start_url 'https://github.com/google/brotli/tags';
 


### PR DESCRIPTION
I tested it with missing bc and it's working.