### PR TITLE
Add exe() method to diag output

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{ $dist->name }}:
 
 {{$NEXT}}
+  [Tests]
+  - Add exe() method to diagnostics (mspacek).
 
 v0.2.2    2022-09-03 13:40:15+01:00 Europe/London
   [Bug Fixes]

--- a/cpanfile
+++ b/cpanfile
@@ -23,7 +23,7 @@ on 'test' => sub {
   requires "Module::Metadata" => "0";
   requires "Test2::V0" => "0";
   requires "Test::Alien" => "0";
-  requires "Test::Alien::Diag" => "0";
+  requires "Test::Alien::Diag" => "2.68";
   requires "Test::More" => "0";
 };
 

--- a/dist.ini
+++ b/dist.ini
@@ -27,11 +27,14 @@ exclude_filename = MANIFEST.SKIP
 
 [RecommendedPrereqs]
 [AutoPrereqs]
-[Prereqs]
+[Prereqs / Build]
 -phase = build
 Alien::bc::GNU = 0
 Alien::cmake3 = 0
 Alien::Build::Plugin::Probe::CommandLine = 0
+[Prereqs / Test]
+-phase = test
+Test::Alien::Diag = 2.68
 
 [EnsurePrereqsInstalled]
 :version = 0.003

--- a/t/01-brotli.t
+++ b/t/01-brotli.t
@@ -3,7 +3,7 @@ use Test::Alien;
 use Test::Alien::Diag;
 use Alien::Brotli;
 
-alien_diag 'Alien::Brotli';
+alien_diag 'Alien::Brotli', { 'properties' => ['exe'] };
 alien_ok 'Alien::Brotli';
 
 ok my $exe = Alien::Brotli->exe, 'exe';


### PR DESCRIPTION
Possibility of alien_diag() with explicit methods is supported in
Test::Alien::Diag@2.68